### PR TITLE
Video view layout modified

### DIFF
--- a/VideoStreaming/SubViews/Cells/VideoTableViewCell.xib
+++ b/VideoStreaming/SubViews/Cells/VideoTableViewCell.xib
@@ -17,15 +17,15 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" restorationIdentifier="VideoView" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4D7-2a-y4u" customClass="VideoView" customModule="VideoStreaming" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="413" height="135"/>
+                        <rect key="frame" x="0.0" y="0.0" width="413" height="100"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     </view>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="4D7-2a-y4u" firstAttribute="height" secondItem="H2p-sc-9uM" secondAttribute="height" constant="35" id="Lmp-86-1BP"/>
-                    <constraint firstItem="4D7-2a-y4u" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" id="XeS-hf-4Ch"/>
-                    <constraint firstItem="4D7-2a-y4u" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="hFc-WU-U61"/>
-                    <constraint firstItem="4D7-2a-y4u" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" constant="17.5" id="vBM-sJ-6a3"/>
+                    <constraint firstAttribute="trailing" secondItem="4D7-2a-y4u" secondAttribute="trailing" id="42j-Mn-9NM"/>
+                    <constraint firstAttribute="bottom" secondItem="4D7-2a-y4u" secondAttribute="bottom" id="dUE-KZ-bHH"/>
+                    <constraint firstItem="4D7-2a-y4u" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="ugh-zK-hqM"/>
+                    <constraint firstItem="4D7-2a-y4u" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="yHc-jG-W4Y"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/VideoStreaming/SubViews/Views/VideoView.swift
+++ b/VideoStreaming/SubViews/Views/VideoView.swift
@@ -35,8 +35,11 @@ class VideoView: UIView {
         videoImageView.sd_setImage(with: nil, placeholderImage: UIImage(named: Constants.placeholderImageName), options: .continueInBackground, context: nil)
         videoTitle.text = video.title
         videoDurationAndDate.text = video.durationAndDate
+        videoTitle.numberOfLines = 0
+        videoTitle.translatesAutoresizingMaskIntoConstraints = false
         videoImageView.translatesAutoresizingMaskIntoConstraints = true
-        videoStack.translatesAutoresizingMaskIntoConstraints = true
+        videoStack.alignment = .leading
+        videoStack.translatesAutoresizingMaskIntoConstraints = false
         videoImageView.layer.masksToBounds = true
         videoImageView.layer.cornerRadius = 10
     }

--- a/VideoStreaming/SubViews/Views/VideoView.xib
+++ b/VideoStreaming/SubViews/Views/VideoView.xib
@@ -17,50 +17,60 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="135"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hpU-Y2-bOK">
-                    <rect key="frame" x="12" y="20" width="149" height="88"/>
+                    <rect key="frame" x="13" y="11" width="116" height="77"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                             <integer key="value" value="10"/>
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                 </imageView>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qcZ-cg-e3F">
-                    <rect key="frame" x="169" y="38" width="225" height="53.5"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="qcZ-cg-e3F">
+                    <rect key="frame" x="144" y="24" width="225" height="41.5"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9e-U2-Vnt">
-                            <rect key="frame" x="0.0" y="0.0" width="225" height="24"/>
-                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9e-U2-Vnt">
+                            <rect key="frame" x="0.0" y="0.0" width="225" height="19.5"/>
+                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
+                            <variation key="heightClass=regular-widthClass=regular">
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
+                            </variation>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Duration &amp; Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YIK-jS-oQG">
-                            <rect key="frame" x="0.0" y="32" width="225" height="21.5"/>
-                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                            <rect key="frame" x="0.0" y="23.5" width="225" height="18"/>
+                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                             <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
                             <nil key="highlightedColor"/>
+                            <variation key="heightClass=regular-widthClass=regular">
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="13"/>
+                            </variation>
                         </label>
                     </subviews>
                     <constraints>
-                        <constraint firstAttribute="width" constant="225" id="ehO-zF-EUc"/>
+                        <constraint firstAttribute="trailing" secondItem="C9e-U2-Vnt" secondAttribute="trailing" id="bTd-34-AtO"/>
+                        <constraint firstAttribute="width" constant="225" id="ehO-zF-EUc">
+                            <variation key="heightClass=regular-widthClass=regular" constant="200"/>
+                        </constraint>
+                        <constraint firstItem="C9e-U2-Vnt" firstAttribute="leading" secondItem="qcZ-cg-e3F" secondAttribute="leading" id="gcl-g1-dIV"/>
                     </constraints>
                 </stackView>
             </subviews>
             <color key="backgroundColor" red="0.086865715523857912" green="0.085475168151187025" blue="0.086170439643647304" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="qcZ-cg-e3F" firstAttribute="leading" secondItem="hpU-Y2-bOK" secondAttribute="trailing" constant="8" id="0nb-0E-YP4"/>
-                <constraint firstItem="qcZ-cg-e3F" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="38" id="7ng-qX-sNf"/>
-                <constraint firstItem="hpU-Y2-bOK" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="20" id="86Q-Yf-OhX"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="hpU-Y2-bOK" secondAttribute="bottom" constant="27" id="GIc-vO-UAu"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="qcZ-cg-e3F" secondAttribute="trailing" constant="20" id="tjT-X6-j2X"/>
-                <constraint firstItem="hpU-Y2-bOK" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="12" id="yeg-al-SNh"/>
+                <constraint firstItem="qcZ-cg-e3F" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="24" id="7ng-qX-sNf"/>
+                <constraint firstItem="hpU-Y2-bOK" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="11" id="86Q-Yf-OhX"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="hpU-Y2-bOK" secondAttribute="bottom" constant="12" id="GIc-vO-UAu"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="qcZ-cg-e3F" secondAttribute="trailing" constant="45" id="HPF-vi-SBc"/>
+                <constraint firstItem="qcZ-cg-e3F" firstAttribute="leading" secondItem="hpU-Y2-bOK" secondAttribute="trailing" constant="15" id="hur-Db-9tA"/>
+                <constraint firstItem="hpU-Y2-bOK" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="13" id="yeg-al-SNh"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <point key="canvasLocation" x="151.19999999999999" y="-88.15592203898052"/>
+            <point key="canvasLocation" x="150.40000000000001" y="-98.050974512743636"/>
         </view>
     </objects>
 </document>

--- a/VideoStreaming/VideoPlaylistViewController.swift
+++ b/VideoStreaming/VideoPlaylistViewController.swift
@@ -14,10 +14,12 @@ class VideoPlaylistViewController: UIViewController {
     
     private var videos = [
         Video(title: "The Hupmobile (Ep. 1)", duration: "20:30", date: Date(), imageName: "hupmobile"),
-        Video(title: "The Hupmobile (Ep. 1)", duration: "20:30", date: Date(), imageName: "hupmobile"),
-        Video(title: "The Hupmobile (Ep. 1)", duration: "20:30", date: Date(), imageName: "hupmobile"),
-        Video(title: "The Hupmobile (Ep. 1)", duration: "20:30", date: Date(), imageName: "hupmobile"),
-        Video(title: "The Hupmobile (Ep. 1)", duration: "20:30", date: Date(), imageName: "hupmobile")
+        Video(title: "The Greatest Catch (Ep. 2)", duration: "16:30", date: Date(), imageName: "hupmobile"),
+        Video(title: "History of the QB (Ep. 3)", duration: "22:30", date: Date(), imageName: "hupmobile"),
+        Video(title: "The Draft (Ep. 4)", duration: "12:30", date: Date(), imageName: "hupmobile"),
+        Video(title: "The Evolution of the Wide Receiver (Ep. 5)", duration: "10:30", date: Date(), imageName: "hupmobile"),
+        Video(title: "Ray Lewis (Ep. 6)", duration: "16:30", date: Date(), imageName: "hupmobile"),
+        Video(title: "The Origins of Fantasy Football (Ep. 7)", duration: "20:30", date: Date(), imageName: "hupmobile")
     ]
     
     var playlist : [Video?] = []
@@ -52,7 +54,7 @@ class VideoPlaylistViewController: UIViewController {
 extension VideoPlaylistViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 135
+        return 100
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {


### PR DESCRIPTION
### **On this PR**

I wanted to improve the layout of the video view. I change the constrains for the stack view which contains the title of the video and the date of publication. Then I resized the text to be smaller. I prove this layout on the iPhone 8, iPhone 11 and iPhone 11 Max.

![Screen Shot 2019-09-27 at 11 36 58](https://user-images.githubusercontent.com/50028597/65778604-9bc19600-e11c-11e9-8959-611a1be80b66.png)
